### PR TITLE
fix: bitcoin-cli try to load wallet before creation

### DIFF
--- a/scripts/create-wallet
+++ b/scripts/create-wallet
@@ -1,1 +1,1 @@
-/opt/bitcoin-knots/bin/bitcoin-cli -regtest -rpcpassword=rpc -rpcuser=rpc createwallet default_wallet
+/opt/bitcoin-knots/bin/bitcoin-cli -regtest -rpcpassword=rpc -rpcuser=rpc loadwallet default_wallet || /opt/bitcoin-knots/bin/bitcoin-cli -regtest -rpcpassword=rpc -rpcuser=rpc createwallet default_wallet


### PR DESCRIPTION
Finally found out where the problem is:

`make start` for the first time will create default_wallet
`make stop` will not clear data in container (default_wallet is there)
`make start` for the second time will try to create default_wallet (but fails) => faucet wont work (throws rpcclient wallet not created error)

 