### PR TITLE
Fix arm64 build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN rm -rf /packages
 # Install WalletWasabi
 RUN apt-get install -y libx11-dev libice-dev libsm-dev libfontconfig1
 COPY vendor/WalletWasabi /opt/WalletWasabi
-RUN cd /opt/WalletWasabi/ && dotnet build
+RUN cd /opt/WalletWasabi/ && DOTNET_EnableWriteXorExecute=0 dotnet build
 
 # Install faucet
 COPY faucet /opt/faucet


### PR DESCRIPTION
The original issue may be related to https://github.com/dotnet/sdk/issues/27190. See also https://devblogs.microsoft.com/dotnet/announcing-net-6-preview-7/#runtime-wx-write-xor-execute-support-for-all-platforms-and-architectures.