### PR TITLE
chore: use WabiSabiClientLibrary from github releases

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "vendor/WalletWasabi"]
 	path = vendor/WalletWasabi
-	url = git@github.com:trezor/WalletWasabi.git
+	url = git@github.com:zkSNACKs/WalletWasabi.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,13 @@ RUN rm -rf /packages
 COPY vendor/WalletWasabi /opt/WalletWasabi
 RUN cd /opt/WalletWasabi/ && DOTNET_EnableWriteXorExecute=0 dotnet build
 
+# Download middleware debug build
+RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then ARCHITECTURE_MIDDLEWARE=x64; elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCHITECTURE_MIDDLEWARE=arm64; else ARCHITECTURE_MIDDLEWARE=x64; fi \
+  && mkdir /opt/middleware \
+  && wget https://github.com/trezor/WalletWasabi/releases/latest/download/WabiSabiClientLibrary-linux-${ARCHITECTURE_MIDDLEWARE}-debug -O /opt/middleware/WalletWasabi.WabiSabiClientLibrary \
+  && wget https://github.com/trezor/WalletWasabi/releases/latest/download/WalletWasabi.WabiSabiClientLibrary.xml -O /opt/middleware/WalletWasabi.WabiSabiClientLibrary.xml \
+  && chmod +x /opt/middleware/WalletWasabi.WabiSabiClientLibrary
+
 # Install faucet
 COPY faucet /opt/faucet
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build vendor build-image create-container start stop run-wallet
 
 
-build: build-image create-container
+build: vendor build-image create-container
 
 vendor:
 	git submodule update --init --recursive --force

--- a/README.md
+++ b/README.md
@@ -40,6 +40,20 @@ The command `make create-container` rebuilds the container which resets the netw
 Use command `make run-wallet` to start WasabiWallet GUI with already preloaded accounts (no password).
 For convenience also `Trezor` accounts with `all all` seed (no passphrase) are preloaded.
 
+## Using custom WabiSabiClientLibrary (middleware)
+
+Download artifacts from [github action](https://github.com/trezor/WalletWasabi/actions/workflows/build-WabiSabiClientLibrary-binary.yaml) unzip files and make them executable.
+
+```
+unzip ~/Downloads/WabiSabiClientLibrary-bin.zip -d ~/Downloads/WabiSabiClientLibrary
+chmod +x ~/Downloads/WabiSabiClientLibrary/*/publish/WalletWasabi.WabiSabiClientLibrary
+```
+
+Start `coinjoin-backend` image with mounted middleware:
+```
+docker run -d --net host -v ~/Downloads/WabiSabiClientLibrary/linux-x64/publish:/mnt/middleware coinjoin-backend-image
+```
+
 ## Proxy
 
 For development in browser environment proxy accepts preflight `OPTIONS` requests and overrides `Access-Control-Allow-Origin` header

--- a/scripts/wasabi-middleware
+++ b/scripts/wasabi-middleware
@@ -1,1 +1,7 @@
-cd /opt/WalletWasabi/WalletWasabi.WabiSabiClientLibrary/ && dotnet run &
+MOUNTED_MIDDLEWARE="/mnt/middleware/WalletWasabi.WabiSabiClientLibrary"
+if [ -f "$MOUNTED_MIDDLEWARE" ]; then
+    echo "Using external middleware binary ${MOUNTED_MIDDLEWARE}"
+    /mnt/middleware/WalletWasabi.WabiSabiClientLibrary &
+else
+    /opt/middleware/WalletWasabi.WabiSabiClientLibrary &
+fi


### PR DESCRIPTION
- download WabiSabiClientLibrary from github releases
- allow mount custom WabiSabiClientLibrary from local machine
- switch submodule url to `zkSNACKs`