### PR TITLE
Chore/proxy cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,8 @@ stop:
 	docker stop coinjoin-backend-container
 
 run-wallet:
-	docker run -it \
+	xhost + \
+	&& docker run -it \
 		--net host \
 		-v "/tmp/.X11-unix/":"/tmp/.X11-unix/" \
 		-e DISPLAY="${DISPLAY}" \

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ The command `make create-container` rebuilds the container which resets the netw
   * Open http://127.0.0.1:8080 in your browser.
   * Send yourself money.
 
+## Running WasabiWallet GUI from docker
+
+Use command `make run-wallet` to start WasabiWallet GUI with already preloaded accounts (no password).
+For convenience also `Trezor` accounts with `all all` seed (no passphrase) are preloaded.
 
 ## Proxy
 
@@ -46,9 +50,3 @@ For development in browser environment proxy accepts preflight `OPTIONS` request
 - WabiSabi backend http://localhost:8081/backend
 - WabiSabi coordinator http://localhost:8081/backend/wabisabi
 - WabiSabi client http://localhost:8081/client
-
-
-## Running WasabiWallet from docker
-`sudo xhost +`
-
-`docker run -it --net host -v "/tmp/.X11-unix/":"/tmp/.X11-unix/" -e DISPLAY="${DISPLAY}" coinjoin-backend-image "run-environment && wasabi-wallet"`

--- a/README.md
+++ b/README.md
@@ -37,9 +37,12 @@ The command `make create-container` rebuilds the container which resets the netw
   * Open http://127.0.0.1:8080 in your browser.
   * Send yourself money.
 
-## Proxy endpoints:
-- Faucet http://localhost:8081/
-- Blockbook http://localhost:8081/blockbook
+
+## Proxy
+
+For development in browser environment proxy accepts preflight `OPTIONS` requests and overrides `Access-Control-Allow-Origin` header
+
+### Proxy endpoints:
 - WabiSabi backend http://localhost:8081/backend
 - WabiSabi coordinator http://localhost:8081/backend/wabisabi
 - WabiSabi client http://localhost:8081/client

--- a/scripts/proxy
+++ b/scripts/proxy
@@ -9,22 +9,17 @@ import requests
 
 LOCALHOST = "127.0.0.1"
 SERVICES = {
-    "/blockbook": 19121,
     "/backend": 37127,
     "/client": 37128,
 }
 
 def replace_html_links(html, base):
-    # replace 127.0.0.1:19121 to absolute with key (in faucet.html)
-    for key in SERVICES:
-        host = f"http://{LOCALHOST}:{SERVICES[key]}"
-        html = html.replace(host, key)
-    # replace absolute links, blockbook and swagger assets (styles, links, json)
+    # replace absolute links and assets (styles, swagger.json etc.)
     html = html.replace('href="/', 'href="' + base + '/')
     return html
 
 def get_service(path, referer):
-    host = f"{LOCALHOST}:8080" # default service (faucet)
+    host = f"{LOCALHOST}:{SERVICES['/backend']}" # default service
     service_key = ''
     for key in SERVICES:
         search_key = f"{key}/"
@@ -61,7 +56,6 @@ def merge_headers(original: dict, override: dict) -> dict:
 # - access to running services on one address
 # - allows preflight OPTIONS requests (browser usage)
 # - override Access-Control-Allow-Origin header (browser usage)
-
 
 class Server(TCPServer):
     def __init__(


### PR DESCRIPTION
proxy will no longer be used for blockbook because of websockets, therfore it's pointless to reroute anything else than required for development in browser (coordinator + middleware) 