### PR TITLE
Chore/update submodule

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get install -y \
 RUN pip3 install ecdsa==0.16.1
 
 # Install dotnet
-RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 7.0 --install-dir /usr/share/dotnet \
+RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 8.0 --install-dir /usr/share/dotnet \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,8 @@ RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then ARCHITECTURE=amd64; elif [ "$
 
 # Install bitcoin knots
 RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then ARCHITECTURE_KNOTS=x86_64; elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCHITECTURE_KNOTS=aarch64; else ARCHITECTURE_KNOTS=x86_64; fi \
-  && wget https://bitcoinknots.org/~luke-jr/.RISKY/programs/bitcoin/files/bitcoin-knots/23.x/23.0.knots20220529/bitcoin-23.0.knots20220529-${ARCHITECTURE_KNOTS}-linux-gnu.tar.gz -O /packages/bitcoin-23.0.knots20220529-${ARCHITECTURE_KNOTS}-linux-gnu.tar.gz \
-  && tar -xzf /packages/bitcoin-23.0.knots20220529-${ARCHITECTURE_KNOTS}-linux-gnu.tar.gz --one-top-level=/opt/bitcoin-knots/ --strip-components=1
+  && wget https://bitcoinknots.org/files/25.x/25.1.knots20231115/bitcoin-25.1.knots20231115-${ARCHITECTURE_KNOTS}-linux-gnu.tar.gz -O /packages/bitcoin-25.1.knots20231115-${ARCHITECTURE_KNOTS}-linux-gnu.tar.gz \
+  && tar -xzf /packages/bitcoin-25.1.knots20231115-${ARCHITECTURE_KNOTS}-linux-gnu.tar.gz --one-top-level=/opt/bitcoin-knots/ --strip-components=1
 
 RUN rm -rf /packages
 

--- a/shell.nix
+++ b/shell.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     stdenv.cc.cc.lib
     openssl
-    dotnet-sdk_6
+    dotnet-sdk_8
     docker
     fontconfig
     fontconfig.lib

--- a/shell.nix
+++ b/shell.nix
@@ -1,27 +1,20 @@
-# the last successful build of nixpkgs-unstable as of 2023-02-28
+# the last successful build of nixos-unstable as of 2023-10-30
 with import
   (builtins.fetchTarball {
-    url = "https://github.com/NixOS/nixpkgs/archive/7785526659fe5885abbd88a85a23a11bd0617e3c.tar.gz";
-    sha256 = "0sjsy3jihhdmck6hn9lizwvk25kzf5ags1p21xqqn3kj7fv5ax9x";
+    url = "https://github.com/NixOS/nixpkgs/archive/63678e9f3d3afecfeafa0acead6239cdb447574c.tar.gz";
+    sha256 = "0l9b5w9riwhnf80w233plb4y028y2psr6gm8avdkwg7jvlga2j41";
   })
 { };
 
 stdenv.mkDerivation rec {
   name = "coinjoin-backend-dev";
   buildInputs = [
-    stdenv.cc.cc.lib
-    openssl
-    dotnet-sdk_8
     docker
-    fontconfig
-    fontconfig.lib
     git
     xorg.xhost
     xorg.libX11
     xorg.libX11.dev
     xorg.libICE
     xorg.libSM
-    zlib
   ];
-  LD_LIBRARY_PATH = "${(import <nixpkgs> { }).lib.makeLibraryPath buildInputs}";
 }


### PR DESCRIPTION
- update WalletWasabi submodule https://github.com/zkSNACKs/WalletWasabi/commit/3585b1fb4b956b0bdc5b37ee91f6f9b550fef427
- update dotnet to version 8
- update bitcoin-knots, previous version throws 
```
This software is expired, and may be out of consensus. You must choose to upgrade or override this expiration.
error: timeout on transient error: Could not connect to the server 127.0.0.1:18443
```
- update nixpkgs. remove dotnet tools, build is done in docker


All tested locally and works